### PR TITLE
feat: add dev-login endpoint

### DIFF
--- a/app/business/auth_bo.py
+++ b/app/business/auth_bo.py
@@ -7,7 +7,7 @@ import jwt
 from jwt.exceptions import InvalidTokenError
 from fastapi.security import OAuth2AuthorizationCodeBearer
 
-from app.core.common.application.dto import GoogleLoginData
+from app.core.common.application.dto import GoogleLoginData, DevLoginData
 from app.core.users.application.dto.user_dto import UserOut
 from app.core.config import settings
 from app.core.users.infra.database.repositories import UserMongoRepository
@@ -70,6 +70,33 @@ class AuthBusiness:
                 detail="Invalid token"
             )
   
+    @classmethod
+    async def dev_login_service(cls, data: DevLoginData):
+        results = await cls.user_repo.find_with_filters({"email": data.email}, limit=1)
+        user_entity = results[0] if results else None
+
+        if not user_entity:
+            user_entity = UserEntity.create(
+                email=data.email,
+                name=data.name,
+                picture="",
+                google_id="",
+                achievements=[],
+                created_at=datetime.now(timezone.utc),
+                last_login=datetime.now(timezone.utc),
+                progress=UserProgress()
+            )
+            await cls.user_repo.create(user_entity)
+            results = await cls.user_repo.find_with_filters({"email": data.email}, limit=1)
+            user_entity = results[0]
+        else:
+            user_entity.last_login = datetime.now(timezone.utc)
+            await cls.user_repo.update(user_entity.id.value, user_entity)
+
+        user_dto = UserMapper.to_dto(user_entity)
+        access_token = cls.create_access_token(data={"sub": str(user_dto.id)})
+        return {"access_token": access_token, "token_type": "bearer", "user": user_dto}
+
     @staticmethod
     def create_access_token(data: dict, expires_delta: Optional[timedelta] = None):
         to_encode = data.copy()

--- a/app/core/common/application/dto/__init__.py
+++ b/app/core/common/application/dto/__init__.py
@@ -1,10 +1,11 @@
-from .auth import GoogleLoginData
+from .auth import GoogleLoginData, DevLoginData
 from .base import PyObjectId, ObjectId, BaseModel, Field, EmailStr, Optional, List, MongoObjectId
 
 __all__ = (
     "ObjectId",
     "PyObjectId",
     "GoogleLoginData",
+    "DevLoginData",
     "BaseModel",
     "Field",
     "EmailStr",

--- a/app/core/common/application/dto/auth.py
+++ b/app/core/common/application/dto/auth.py
@@ -1,4 +1,8 @@
-from .base import BaseModel
+from .base import BaseModel, EmailStr
 
 class GoogleLoginData(BaseModel):
     token: str
+
+class DevLoginData(BaseModel):
+    email: EmailStr
+    name: str

--- a/app/http/rest/v1/auth_rest.py
+++ b/app/http/rest/v1/auth_rest.py
@@ -1,6 +1,6 @@
 from app.core.config import settings
-from fastapi import APIRouter
-from app.core.common.application.dto import GoogleLoginData
+from fastapi import APIRouter, HTTPException, status
+from app.core.common.application.dto import GoogleLoginData, DevLoginData
 from app.business import AuthBusiness
 
 
@@ -14,3 +14,12 @@ async def google_login(
     data: GoogleLoginData,
 ):
     return await AuthBusiness.google_login_service(data)
+
+@auth_v1.post("/dev-login")
+async def dev_login(data: DevLoginData):
+    if not settings.APP_DEBUG:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="This endpoint is only available in debug mode.",
+        )
+    return await AuthBusiness.dev_login_service(data)

--- a/docs/dev-login.md
+++ b/docs/dev-login.md
@@ -1,0 +1,145 @@
+# Dev Login Endpoint
+
+## Purpose
+
+During local development, the application's only login method is Google OAuth, which requires a real Google account and a valid OAuth token on every session. This is friction for developers and makes it harder to test features that sit behind authentication.
+
+The `POST /api/v1/auth/dev-login` endpoint provides a shortcut: pass an email and a name, get back a JWT — no Google interaction required.
+
+**This endpoint is disabled in production.** It only works when `APP_DEBUG=True`.
+
+---
+
+## Security model
+
+### How it is gated
+
+The endpoint checks `settings.APP_DEBUG` on every request. If the flag is `False`, it returns `403 Forbidden` immediately, before any database access.
+
+```
+APP_DEBUG=False  →  403 Forbidden  (production default)
+APP_DEBUG=True   →  normal login flow  (development only)
+```
+
+### Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Endpoint accidentally enabled in production | `APP_DEBUG` defaults to `False` in `app/core/config.py`; the flag must be explicitly set to `True` |
+| Weak email validation allows malformed input | `EmailStr` (Pydantic) validates the email field at the DTO layer before the service is called |
+| Dev users persist in the production database | Dev login users are only ever created when `APP_DEBUG=True`; the database in production should never have this flag enabled |
+
+### Extra hardening (optional)
+
+For additional safety, you can register the route only when `APP_DEBUG=True` at startup, so the route literally does not exist in production rather than returning 403. This would require a conditional include in `app/http/config.py`.
+
+---
+
+## Alternatives considered
+
+| Approach | Trade-offs |
+|---|---|
+| **Dev login endpoint (this implementation)** | Simple, zero infrastructure. Risk: accidental prod exposure if `APP_DEBUG` is misconfigured. |
+| **Shared test Google account** | No code changes. Requires real internet access, brittle with 2FA, shared credentials. |
+| **Local OAuth mock server** (e.g. Keycloak, dex) | Most realistic — app behaves identically to production. More setup required. Best for security-sensitive teams. |
+| **Magic token bypass in `/google-login`** | Fewer moving parts (one endpoint), but mixes prod and dev logic in the same handler. |
+
+---
+
+## Usage
+
+### 1. Enable debug mode
+
+In your `.env` file:
+
+```env
+APP_DEBUG=True
+```
+
+### 2. Start the server
+
+```bash
+uvicorn app.main:app --reload
+```
+
+### 3. Call the endpoint
+
+**Request**
+
+```
+POST /api/v1/auth/dev-login
+Content-Type: application/json
+
+{
+  "email": "dev@local.com",
+  "name": "Dev User"
+}
+```
+
+**Example with curl**
+
+```bash
+curl -X POST http://127.0.0.1:8000/api/v1/auth/dev-login \
+  -H "Content-Type: application/json" \
+  -d '{"email": "dev@local.com", "name": "Dev User"}'
+```
+
+**Response**
+
+```json
+{
+  "access_token": "<JWT>",
+  "token_type": "bearer",
+  "user": {
+    "id": "...",
+    "email": "dev@local.com",
+    "name": "Dev User",
+    ...
+  }
+}
+```
+
+### 4. Use the token
+
+Include the JWT in the `Authorization` header for any protected endpoint:
+
+```
+Authorization: Bearer <access_token>
+```
+
+### Production behaviour
+
+When `APP_DEBUG=False`:
+
+```
+HTTP 403 Forbidden
+{"detail": "This endpoint is only available in debug mode."}
+```
+
+---
+
+## Code path
+
+```
+POST /api/v1/auth/dev-login
+  └── auth_rest.py: dev_login()
+        ├── Guard: settings.APP_DEBUG → 403 if False
+        └── AuthBusiness.dev_login_service(data)
+              ├── UserMongoRepository.find_with_filters({"email": ...})
+              ├── If user not found → UserEntity.create() → repo.create()
+              │     └── Re-fetch to get DB-assigned _id
+              ├── If user exists → update last_login → repo.update()
+              ├── UserMapper.to_dto(user_entity)
+              ├── AuthBusiness.create_access_token({"sub": user_id})
+              └── Return {access_token, token_type, user}
+```
+
+### Key files
+
+| File | Role |
+|---|---|
+| `app/http/rest/v1/auth_rest.py` | HTTP endpoint + `APP_DEBUG` guard |
+| `app/business/auth_bo.py` | `dev_login_service()` — user lookup/creation and JWT generation |
+| `app/core/common/application/dto/auth.py` | `DevLoginData` DTO (`email: EmailStr`, `name: str`) |
+| `app/core/users/infra/database/repositories/user_mongo_repo.py` | `find_with_filters()` used to look up user by email |
+| `app/core/config.py` | `APP_DEBUG` setting (defaults to `False`) |

--- a/tests/test_auth_rest.py
+++ b/tests/test_auth_rest.py
@@ -88,3 +88,45 @@ async def test_google_login_success_exist_user(
     
     assert result["user"]["email"] == TEST_USER_EMAIL
     assert result["user"]["last_login"] != result["user"]["created_at"]
+
+async def test_dev_login_success_new_user(client: AsyncClient):
+    from app.core.config import settings
+    with patch.object(settings, "APP_DEBUG", True):
+        response = await client.post(
+            f"{BASE_URL}/dev-login",
+            json={"email": "dev@local.com", "name": "Dev User"},
+        )
+
+    assert response.status_code == 200
+    result = response.json()
+    assert "access_token" in result
+    assert result["token_type"] == "bearer"
+    assert result["user"]["email"] == "dev@local.com"
+    assert result["user"]["name"] == "Dev User"
+
+async def test_dev_login_success_existing_user(client: AsyncClient):
+    from app.core.config import settings
+    with patch.object(settings, "APP_DEBUG", True):
+        await client.post(
+            f"{BASE_URL}/dev-login",
+            json={"email": "dev@local.com", "name": "Dev User"},
+        )
+        response = await client.post(
+            f"{BASE_URL}/dev-login",
+            json={"email": "dev@local.com", "name": "Dev User"},
+        )
+
+    assert response.status_code == 200
+    result = response.json()
+    assert result["user"]["email"] == "dev@local.com"
+    assert result["user"]["last_login"] != result["user"]["created_at"]
+
+async def test_dev_login_forbidden_when_not_debug(client: AsyncClient):
+    from app.core.config import settings
+    with patch.object(settings, "APP_DEBUG", False):
+        response = await client.post(
+            f"{BASE_URL}/dev-login",
+            json={"email": "dev@local.com", "name": "Dev User"},
+        )
+
+    assert response.status_code == 403


### PR DESCRIPTION
## Summary
- Add `/dev-login` POST endpoint that allows authentication via email/name without Google OAuth, restricted to debug mode only (`APP_DEBUG=True`)
- Add `DevLoginData` DTO and `dev_login_service` business logic that creates or updates users
- Add tests covering new user creation, existing user login, and forbidden access when debug mode is off

## Test plan
- [x] `test_dev_login_success_new_user` — creates a new user and returns access token
- [x] `test_dev_login_success_existing_user` — logs in existing user and updates last_login
- [x] `test_dev_login_forbidden_when_not_debug` — returns 403 when APP_DEBUG is false

🤖 Generated with [Claude Code](https://claude.com/claude-code)